### PR TITLE
renamed PREC, made OMP importing safe

### DIFF
--- a/QuEST/QuEST.c
+++ b/QuEST/QuEST.c
@@ -25,7 +25,9 @@
 # include <sys/time.h>
 # include <sys/types.h>
 
+# ifdef _OPENMP
 # include <omp.h>
+# endif
 
 const char* errorCodes[] = {
     "Success",                                              // 0

--- a/QuEST/QuEST_env_local.c
+++ b/QuEST/QuEST_env_local.c
@@ -8,7 +8,6 @@
 # include <stdlib.h>
 # include <stdio.h>
 # include <math.h>
-# include <omp.h>
 # include "QuEST_precision.h"
 # include "QuEST.h"
 # include "QuEST_internal.h"
@@ -17,6 +16,10 @@
 
 # include <time.h>
 # include <sys/types.h>
+
+# ifdef _OPENMP
+# include <omp.h>
+# endif
 
 void initQuESTEnv(QuESTEnv *env){
     // init MPI environment

--- a/QuEST/QuEST_env_mpi.c
+++ b/QuEST/QuEST_env_mpi.c
@@ -12,7 +12,6 @@
 # include <stdlib.h>
 # include <stdio.h>
 # include <math.h>
-# include <omp.h>
 # include "QuEST_precision.h"
 # include "QuEST.h"
 # include "QuEST_internal.h"
@@ -21,6 +20,10 @@
 
 # include <time.h>
 # include <sys/types.h>
+
+# ifdef _OPENMP
+# include <omp.h>
+# endif
 
 static int isChunkToSkipInFindPZero(int chunkId, long long int chunkSize, int measureQubit);
 static int chunkIsUpper(int chunkId, long long int chunkSize, int targetQubit);

--- a/QuEST/QuEST_precision.h
+++ b/QuEST/QuEST_precision.h
@@ -5,15 +5,15 @@
 
 // *** EDIT PRECISION HERE
 // OPTIONS: 1, 2, 4
-# define PREC 2
+# define QuEST_PREC 2
 
-# if PREC==1
+# if QuEST_PREC==1
 	// SINGLE PRECISION
 	# define REAL float
 	# define MPI_QuEST_REAL MPI_FLOAT
 	# define REAL_STRING_FORMAT "%.8f"
 	# define REAL_EPS 1e-5
-# elif PREC==4
+# elif QuEST_PREC==4
 	// QUAD PRECISION
 	// 80-bit precision for most implementations
 	# define REAL long double


### PR DESCRIPTION
omp.h should only be imported when used in compilation to avoid errors with compilers which don't support it (e.g. Clang)

I also moved the makefile and tutorialExample out of the main folder